### PR TITLE
feat: add NIC first class fields

### DIFF
--- a/cloud/instance/instance.go
+++ b/cloud/instance/instance.go
@@ -279,6 +279,13 @@ type Graphics struct {
 // NIC is the API payload based on the legacy xmlrpc backend.
 type NIC struct {
 	Values               template.Values `json:"values,omitempty" yaml:"values,omitempty"`
+	NetworkID            string          `json:"network_id" yaml:"network_id" xml:"NETWORK_ID"`
+	IP                   string          `json:"ip" yaml:"ip" xml:"IP"`
+	MAC                  string          `json:"mac" yaml:"mac" xml:"MAC"`
+	Model                string          `json:"model" yaml:"model" xml:"MODEL"`
+	VirtioQueues         string          `json:"virtio_queues" yaml:"virtio_queues" xml:"VIRTIO_QUEUES"`
+	Phydev               string          `json:"phy_dev" yaml:"phy_dev" xml:"PHYDEV"`
+	SecurityGroups       string          `json:"security_groups" yaml:"security_groups" xml:"SECURITY_GROUPS"`
 	VCenterInstanceID    string          `json:"vcenter_instance_id" yaml:"vcenter_instance_id" xml:"VCENTER_INSTANCE_ID"`
 	VCenterNetRef        string          `json:"vcenter_net_ref" yaml:"vcenter_net_ref" xml:"VCENTER_NET_REF"`
 	VCenterPortgroupType string          `json:"vcenter_portgroup_type" yaml:"vcenter_portgroup_type" xml:"VCENTER_PORTGROUP_TYPE"`


### PR DESCRIPTION
Make some NIC fields first class. This results in the xml payload:

```
...
    <MEMORY_RESIZE_MODE></MEMORY_RESIZE_MODE>
    <MEMORY_SLOTS></MEMORY_SLOTS>
    <NIC>
        <NETWORK_ID>2</NETWORK_ID>
        <IP></IP>
        <MAC></MAC>
        <MODEL></MODEL>
        <VIRTIO_QUEUES></VIRTIO_QUEUES>
        <PHYDEV></PHYDEV>
        <SECURITY_GROUPS>101</SECURITY_GROUPS>
        <VCENTER_INSTANCE_ID></VCENTER_INSTANCE_ID>
        <VCENTER_NET_REF></VCENTER_NET_REF>
        <VCENTER_PORTGROUP_TYPE></VCENTER_PORTGROUP_TYPE>
    </NIC>
...
```