### PR TITLE
fix: explicit fields for CreateSecurityGroupRequest

### DIFF
--- a/cloud/requests.go
+++ b/cloud/requests.go
@@ -130,7 +130,7 @@ type UpdateGroupRequest struct {
 }
 
 // SetTemplate sets r.Template from its structured representation. Either call
-// this of set the template string directly.
+// this or set the template string directly.
 func (r *UpdateGroupRequest) SetTemplate(t GroupTemplate) {
 	r.Template = NewTemplate(t).String()
 }
@@ -226,7 +226,7 @@ type CreateImageRequest struct {
 }
 
 // SetTemplate sets r.Template from its structured representation. Either call
-// this of set the template string directly.
+// this or set the template string directly.
 func (r *CreateImageRequest) SetTemplate(t ImageTemplate) {
 	r.Template = NewTemplate(t).String()
 }
@@ -259,7 +259,7 @@ type UpdateImageRequest struct {
 }
 
 // SetTemplate sets r.Template from its structured representation. Either call
-// this of set the template string directly.
+// this or set the template string directly.
 func (r *UpdateImageRequest) SetTemplate(t ImageTemplate) {
 	r.Template = NewTemplate(t).String()
 }
@@ -297,7 +297,7 @@ type CreateInstanceRequest struct {
 }
 
 // SetTemplate sets r.Template from its structured representation. Either call
-// this of set the template string directly.
+// this or set the template string directly.
 func (r *CreateInstanceRequest) SetTemplate(t InstanceTemplate) {
 	r.Template = NewTemplate(t).String()
 }
@@ -437,6 +437,12 @@ type CreateSecurityGroupRequest struct {
 	Template string `json:"template"`
 }
 
+// SetTemplate sets r.Template from its structured representation. Either call
+// this or set the template string directly.
+func (r *CreateSecurityGroupRequest) SetTemplate(t SecurityGroupTemplate) {
+	r.Template = NewTemplate(t).String()
+}
+
 // CloneSecurityGroupRequest is the request body for POST /cloud/security-group/{sg}/clone.
 type CloneSecurityGroupRequest struct {
 	Name string `json:"name"`
@@ -553,7 +559,7 @@ type UpdateUserRequest struct {
 }
 
 // SetTemplate sets r.Template from its structured representation. Either call
-// this of set the template string directly.
+// this or set the template string directly.
 func (r *UpdateUserRequest) SetTemplate(t UserTemplate) {
 	r.Template = NewTemplate(t).String()
 }

--- a/cloud/service_sg.go
+++ b/cloud/service_sg.go
@@ -16,7 +16,7 @@ func (s SecurityGroupService) DeleteSecurityGroup(ctx context.Context, id int) e
 	return s.Delete(ctx, p, nil)
 }
 
-// SecurityGroup returns information about a image.
+// SecurityGroup returns information about a security group.
 func (s SecurityGroupService) SecurityGroup(ctx context.Context, id int) (*SecurityGroupResponse, error) {
 	var resp SecurityGroupResponse
 
@@ -29,7 +29,7 @@ func (s SecurityGroupService) SecurityGroup(ctx context.Context, id int) (*Secur
 	return &resp, nil
 }
 
-// SecurityGroups returns information about all images.
+// SecurityGroups returns information about all security groups.
 func (s SecurityGroupService) SecurityGroups(ctx context.Context) (*SecurityGroupsResponse, error) {
 	var resp SecurityGroupsResponse
 
@@ -110,7 +110,6 @@ func (s SecurityGroupService) RenameSecurityGroup(ctx context.Context, id int, r
 // CreateSecurityGroup creates a new security group.
 func (s SecurityGroupService) CreateSecurityGroup(ctx context.Context, req CreateSecurityGroupRequest) (*CreateSecurityGroupResponse, error) {
 	var resp CreateSecurityGroupResponse
-
 	p := s.path(SecurityGroupPath)
 
 	if err := s.Post(ctx, p, req, &resp); err != nil {

--- a/cloud/sg.go
+++ b/cloud/sg.go
@@ -18,14 +18,20 @@ type SecurityGroup struct {
 
 // SecurityGroupTemplate is the API payload based on the legacy xmlrpc backend.
 type SecurityGroupTemplate struct {
+	Name        string
 	Description string
 	Rule        []SecurityGroupRule
 }
 
 // SecurityGroupRule is the API payload based on the legacy xmlrpc backend.
 type SecurityGroupRule struct {
-	Protocol string `json:"protocol" yaml:"protocol"`
-	RuleType string `json:"rule_type" yaml:"rule_type"`
+	ICMPType  string `json:"icmp_type" yaml:"icmp_type"`
+	IP        string `json:"ip" yaml:"ip"`
+	NetworkID string `json:"network_id" yaml:"network_id"`
+	Protocol  string `json:"protocol" yaml:"protocol"`
+	Range     string `json:"range" yaml:"range"`
+	RuleType  string `json:"rule_type" yaml:"rule_type"`
+	Size      string `json:"size" yaml:"size"`
 }
 
 // ParseTemplate returns a structured subset of the nested key x value pair map.
@@ -37,6 +43,10 @@ func (g *SecurityGroup) ParseTemplate() (*SecurityGroupTemplate, error) {
 		case string:
 			if key == "DESCRIPTION" {
 				t.Description = v
+			}
+
+			if key == "NAME" {
+				t.Name = v
 			}
 		case map[string]any:
 			if key == "RULE" {
@@ -64,6 +74,14 @@ func newSecurityGroupRule(m map[string]any) *SecurityGroupRule {
 				r.Protocol = v
 			case "RULE_TYPE":
 				r.RuleType = v
+			case "IP":
+				r.IP = v
+			case "RANGE":
+				r.Range = v
+			case "ICMP_TYPE":
+				r.ICMPType = v
+			case "NETWORK_ID":
+				r.NetworkID = v
 			}
 		}
 	}


### PR DESCRIPTION
~Change the `CreateSecurityGroupRequest` to include fields of specific data required for creating a security group. This deviates from the request objects only using a "Template" field. The idea is here is so that manifold has an explicit contract and handles marshaling. This PR's implementation of marshaling could be improved (e.g. helper funcs) but this is  more of a POC.~

~Status quo requires the caller of manifold to marshal a string payload everywhere.~

~Could this be a pattern we want to follow going forward?~

Moving forward with SetTemplate() by the caller. This PR just adds new security group rules.