### PR TITLE
feat: ability to set specific context fields

### DIFF
--- a/cloud/instance/instance.go
+++ b/cloud/instance/instance.go
@@ -121,6 +121,7 @@ type Template struct {
 	MemoryMax                 string
 	MemoryResizeMode          string
 	MemorySlots               string
+	Name                      string
 	NIC                       []NIC
 	NICAlias                  []NICAlias
 	NICDefault                string
@@ -156,6 +157,7 @@ type Context struct {
 	Network      bool
 	SSHPublicKey string
 	Target       string
+	ProjectName  string
 }
 
 // OS is the API payload based on the legacy xmlrpc backend.

--- a/cloud/instance/template.go
+++ b/cloud/instance/template.go
@@ -232,7 +232,7 @@ func newInstanceContext(m map[string]any) (*Context, error) {
 	var dst Context
 
 	for key, value := range m {
-		err := SetContextValue(&dst, key, value)
+		err := dst.Set(key, value)
 		if err != nil {
 			return nil, err
 		}
@@ -241,10 +241,14 @@ func newInstanceContext(m map[string]any) (*Context, error) {
 	return &dst, nil
 }
 
-// SetContextValue sets a key:value for the given context
+// Set sets a key:value for the given context
 // The key must match known fields and named with capital letters with underscores
 // e.g. DISK_ID, SSH_PUBLIC_KEY, etc.
-func SetContextValue(dst *Context, key string, value any) error {
+func (c *Context) Set(key string, value any) error {
+	return setContextValue(c, key, value)
+}
+
+func setContextValue(dst *Context, key string, value any) error {
 	if v, ok := value.(string); ok {
 		switch key {
 		case "DISK_ID":
@@ -269,10 +273,12 @@ func SetContextValue(dst *Context, key string, value any) error {
 			dst.Target = v
 		case "PROJECT_NAME":
 			dst.ProjectName = v
+		default:
+			return fmt.Errorf("unknown key: %s", key)
 		}
 	}
 
-	return fmt.Errorf("unknown key: %s", key)
+	return nil
 }
 
 func newInstanceCPUModel(m map[string]any) *CPUModel {

--- a/cloud/instance/template.go
+++ b/cloud/instance/template.go
@@ -232,33 +232,47 @@ func newInstanceContext(m map[string]any) (*Context, error) {
 	var dst Context
 
 	for key, value := range m {
-		if v, ok := value.(string); ok {
-			switch key {
-			case "DISK_ID":
-				n, err := strconv.Atoi(v)
-				if err != nil {
-					return nil, fmt.Errorf("invalid DISK_ID value %q: %w", v, err)
-				}
-				dst.DiskID = n
-			case "FIRMWARE":
-				dst.Firmware = v
-			case "GUESTOS":
-				dst.GuestOS = v
-			case "NETWORK":
-				b, err := api.Str2Bool(v)
-				if err != nil {
-					return nil, fmt.Errorf("invalid NETWORK value %q: %w", v, err)
-				}
-				dst.Network = b
-			case "SSH_PUBLIC_KEY":
-				dst.SSHPublicKey = v
-			case "TARGET":
-				dst.Target = v
-			}
+		err := SetContextValue(&dst, key, value)
+		if err != nil {
+			return nil, err
 		}
 	}
 
 	return &dst, nil
+}
+
+// SetContextValue sets a key:value for the given context
+// The key must match known fields and named with capital letters with underscores
+// e.g. DISK_ID, SSH_PUBLIC_KEY, etc.
+func SetContextValue(dst *Context, key string, value any) error {
+	if v, ok := value.(string); ok {
+		switch key {
+		case "DISK_ID":
+			n, err := strconv.Atoi(v)
+			if err != nil {
+				return fmt.Errorf("invalid DISK_ID value %q: %w", v, err)
+			}
+			dst.DiskID = n
+		case "FIRMWARE":
+			dst.Firmware = v
+		case "GUESTOS":
+			dst.GuestOS = v
+		case "NETWORK":
+			b, err := api.Str2Bool(v)
+			if err != nil {
+				return fmt.Errorf("invalid NETWORK value %q: %w", v, err)
+			}
+			dst.Network = b
+		case "SSH_PUBLIC_KEY":
+			dst.SSHPublicKey = v
+		case "TARGET":
+			dst.Target = v
+		case "PROJECT_NAME":
+			dst.ProjectName = v
+		}
+	}
+
+	return fmt.Errorf("unknown key: %s", key)
 }
 
 func newInstanceCPUModel(m map[string]any) *CPUModel {


### PR DESCRIPTION
This changes adds the ability to set a specific context field based on its CAPITALIZED_FORMAT. The reason behind this was to set up a context instance without have to override all of the other fields. Basically a merge of new values only. This method allows that without duplicating the switch statement.