### PR TITLE
fix: add more VM context keys

### DIFF
--- a/cloud/instance/instance.go
+++ b/cloud/instance/instance.go
@@ -155,9 +155,11 @@ type Context struct {
 	Firmware     string
 	GuestOS      string
 	Network      bool
-	SSHPublicKey string
 	Target       string
+	Token        bool
 	ProjectName  string
+	SetHostname  string
+	SSHPublicKey string
 }
 
 // OS is the API payload based on the legacy xmlrpc backend.

--- a/cloud/instance/template.go
+++ b/cloud/instance/template.go
@@ -273,6 +273,14 @@ func setContextValue(dst *Context, key string, value any) error {
 			dst.Target = v
 		case "PROJECT_NAME":
 			dst.ProjectName = v
+		case "SET_HOSTNAME":
+			dst.SetHostname = v
+		case "TOKEN":
+			b, err := api.Str2Bool(v)
+			if err != nil {
+				return fmt.Errorf("invalid TOKEN value %q: %w", v, err)
+			}
+			dst.Token = b
 		default:
 			return fmt.Errorf("unknown key: %s", key)
 		}

--- a/cloud/responses.go
+++ b/cloud/responses.go
@@ -906,9 +906,9 @@ type DeleteTemplateResponse struct {
 	Template int `json:"template"`
 }
 
-// InstantiateTemplateResponse is the response body for DELETE /cloud/template/{template}.
+// InstantiateTemplateResponse is the response body for POST /cloud/template/{template}.
 type InstantiateTemplateResponse struct {
-	Template int `json:"template"`
+	Instance int `json:"instance"`
 }
 
 // UpdateTemplateResponse is the response body for PATCH /cloud/template.


### PR DESCRIPTION
Changes include renaming of template instantiate response field to reflect that it [returns](https://docs.opennebula.io/6.8/integration_and_development/system_interfaces/api.html#one-template-instantiate) an VM ID,